### PR TITLE
Restructure apiRoutes to add Auth functionality

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,7 @@
       "no-trailing-spaces": "error",
       "default-case": "error",
       "no-fallthrough": "error",
-      "no-unused-vars": "error",
+      "no-unused-vars": "warn",
       "no-use-before-define": "error",
       "no-redeclare": "error",
       "camelcase": "error",

--- a/config/authHelpers.js
+++ b/config/authHelpers.js
@@ -1,0 +1,32 @@
+
+// for testing purposes we can toggle AUTH here.
+const AUTH_ACTIVATED = true;
+
+function isLoggedIn(req, res, next) {
+  if (!AUTH_ACTIVATED) {
+    return next();
+  }
+
+  if (req.isAuthenticated()) {
+    return next();
+  }
+
+  res.redirect('/login');
+}
+
+function isAdmin(req, res, next) {
+  if (!AUTH_ACTIVATED) {
+    return next();
+  }
+
+  if (req.isAuthenticated() && req.user.permissions === 'admin') {
+    return next();
+  }
+
+  res.status(403).send('Requires Admin Permissions');
+}
+
+module.exports = {
+  isLoggedIn: isLoggedIn,
+  isAdmin: isAdmin
+};

--- a/config/authHelpers.js
+++ b/config/authHelpers.js
@@ -1,5 +1,5 @@
-
 // for testing purposes we can toggle AUTH here.
+// WARN: Setting this to false might break some things that require req.user obj
 const AUTH_ACTIVATED = true;
 
 function isLoggedIn(req, res, next) {

--- a/routes/apiRoutes.js
+++ b/routes/apiRoutes.js
@@ -1,123 +1,11 @@
-var db = require('../models');
-
-var resources = {
-  users: 'User',
-  collections: 'Collection',
-  items: 'Item',
-  opportunities: 'Opportunity'
-};
-
-// for testing purposes we can toggle AUTH here.
-const AUTH_ACTIVATED = true;
-
-function paramToResourceKey(param) {
-  if (Object.keys(resources[param])) {
-    return resources[param];
-  }
-  return undefined;
-}
-
-function isLoggedIn(req, res, next) {
-  if (!AUTH_ACTIVATED) {
-    return next();
-  }
-
-  if (req.isAuthenticated()) {
-    return next();
-  }
-
-  res.redirect('/login');
-}
-
-function isAdmin(req, res, next) {
-  if (!AUTH_ACTIVATED) {
-    return next();
-  }
-
-  if (req.isAuthenticated()) {
-    User.findById(req.user.id).then(dbUser => {
-      if (dbUser.permissions === 'admin') {
-        return next();
-      } else {
-        res.send('Need Admin permissions');
-      }
-    });
-  }
-}
+const db = require('../models');
+const auth = require('../config/authHelpers');
 
 module.exports = function (app /*, passport */) {
 
-  /*******************\
-    |  GENERAL ROUTING  |
-    \*******************/
-
-  // We can get rid of a lot of the repetition by generalizing how we interact
-  // with the different database objects.  This scheme may have to change when
-  // we introduce authentication...
-
-  app.get('/api/users/me', isLoggedIn, function (req, res) {
-    res.json({ id: req.user.id, name: req.user.name, email: req.user.email, permissions: req.user.permissions });
-  });
-
-  app.get('/api/:resource', function (req, res) {
-    let key = paramToResourceKey(req.params.resource);
-    if (key) {
-      db[key].findAll({}).then(data => res.json(data));
-    } else {
-      res.status(404).send('Not Found');
-    }
-  });
-
-  app.get('/api/:resource/:id', function (req, res) {
-    let key = paramToResourceKey(req.params.resource);
-    if (key) {
-      db[key].findById(req.params.id).then(data => res.json(data));
-    } else {
-      res.status(404).send('Not Found');
-    }
-  });
-
-  app.post('/api/:resource', isLoggedIn, function (req, res) {
-    let key = paramToResourceKey(req.params.resource);
-    if (key) {
-      db[key]
-        .create(req.body)
-        .then(data => res.json(data))
-        .catch(err => res.status(500).send(`Create ${key} Error. \n${err}`));
-    } else {
-      res.status(404).send('Not Found');
-    }
-  });
-
-  app.put('/api/:resource/:id', isAdmin, function (req, res) {
-    let key = paramToResourceKey(req.params.resource);
-    if (key) {
-      db[key]
-        .update(req.body, { where: { id: req.params.id } })
-        .then(data => res.json(data))
-        .catch(err => res.status(500).send(err));
-    } else {
-      res.status(404).send('Not Found');
-    }
-  });
-
-  app.delete('/api/:resource/:id', function (req, res) {
-    let key = paramToResourceKey(req.params.resource);
-    if (key) {
-      db[key]
-        .destroy({ where: { id: req.params.id } })
-        .then(data => res.json(data))
-        .catch(err => res.status(500).send(err));
-    } else {
-      res.status(404).send('Not Found');
-    }
-  });
-
-  /*******************\
-  |  SPECIAL ROUTING  |
-  \*******************/
-
-  // These are particular patterns that will only be used for these routes.
+  /******************\
+  |  PUBLIC ROUTING  |
+  \******************/
 
   app.get('/api/users/:id/collections', function (req, res) {
     db.Collection
@@ -135,141 +23,173 @@ module.exports = function (app /*, passport */) {
       });
   });
 
-  /**************\
-  |  OLD ROUTES  |
-  \**************/
+  app.get('/api/collections', function (req, res) {
+    db.Collection.findAll({}).then(function (dbCollections) {
+      res.json(dbCollections);
+    });
+  });
 
-  // These are all the routes that would be used if we did not generalize the access logic above.
+  app.get('/api/collections/:id', function (req, res) {
+    db.Collection.findById(req.params.id).then(function (dbCollection) {
+      res.json(dbCollection);
+    });
+  });
 
-  // // USER API CALLS
-  // app.get('/api/users', function (req, res) {
-  //   db.User.findAll({}).then(function (data) {
-  //     res.json(data);
-  //   });
-  // });
+  app.get('/api/items', function (req, res) {
+    db.Item.findAll({}).then(function (dbItems) {
+      res.json(dbItems);
+    });
+  });
 
-  // app.get('/api/users/:id', function (req, res) {
-  //   db.User.findById(req.params.id).then(function (dbUser) {
-  //     res.json(dbUser);
-  //   });
-  // });
+  app.get('/api/items/:id', function (req, res) {
+    db.Item.findById(req.params.id).then(function (dbItem) {
+      res.json(dbItem);
+    });
+  });
 
-  // app.post('/api/users', function (req, res) {
-  //   // expects an object with properties 'name', 'email', 'bio'
-  //   db.User.create(req.body).then(function (dbUser) {
-  //     res.json(dbUser);
-  //   });
-  // });
+  app.get('/api/opportunities', function (req, res) {
+    db.Opportunity.findAll({}).then(function (dbOp) {
+      res.json(dbOp);
+    });
+  });
 
-  // app.delete('/api/users/:id', function (req, res) {
-  //   db.User.destroy({ where: { id: req.params.id } }).then(function (dbUser) {
-  //     res.json(dbUser);
-  //   });
-  // });
+  app.get('/api/opportunities/:id', function (req, res) {
+    db.Opportunity.findById(req.params.id).then(function (dbOp) {
+      res.json(dbOp);
+    });
+  });
 
-  // app.put('/api/users/:id', function (req, res) {
-  //   db.User.update(req.body, { where: { id: req.params.id } }).then(function (dbUser) {
-  //     res.json(dbUser);
-  //   });
-  // });
+  /************************\
+  |  AUTHENTICATED ROUTES  |
+  \************************/
+
+  app.get('/api/users/me', auth.isLoggedIn, function (req, res) {
+    res.json({
+      id: req.user.id,
+      name: req.user.name,
+      email: req.user.email,
+      permissions: req.user.permissions
+    });
+  });
+
+  app.get('/api/users/:id', auth.isLoggedIn, function (req, res) {
+    if (req.user.id === req.params.id || req.user.permissions === 'admin') {
+      db.User.findById(req.params.id).then(function (dbUser) {
+        res.json(dbUser);
+      });
+    } else {
+      res.status(403).send('You do not have permission to get this resource');
+    }
+  });
+
+  app.post('/api/collections', auth.isLoggedIn, function (req, res) {
+    // expects an object with properties 'name', 'description', 'UserId'
+    // we can set 'UserId' with req.user.id
+    // TODO: Add validation to ensure req.body has proper structure
+    db.Collection.create(req.body).then(function (dbCollection) {
+      res.json(dbCollection);
+    });
+  });
 
 
-  // // COLLECTIONS API CALLS
-  // app.get('/api/collections', function (req, res) {
-  //   db.Collection.findAll({}).then(function (dbCollections) {
-  //     res.json(dbCollections);
-  //   });
-  // });
+  app.delete('/api/collection/:id', auth.isLoggedIn, function (req, res) {
+    let conditions = { where: { id: req.params.id } };
 
-  // app.get('/api/collections/:id', function (req, res) {
-  //   db.Collection.findById(req.params.id).then(function (dbCollection) {
-  //     res.json(dbCollection);
-  //   });
-  // });
+    if (!req.params.permissions === 'admin') {
+      conditions.where.UserId = req.user.id;
+    }
 
-  // app.post('/api/collections', function (req, res) {
-  //   // expects an object with properties 'name', 'description', 'UserId'
-  //   db.Collection.create(req.body).then(function (dbCollection) {
-  //     res.json(dbCollection);
-  //   });
-  // });
+    db.Collection.destroy(conditions).then(function (dbCollection) {
+      res.json(dbCollection);
+    });
+  });
+
+  app.put('/api/collections/:id', auth.isLoggedIn, function (req, res) {
+    // expects an object with properties 'name', 'description', 'UserId'
+    // we can set 'UserId' with req.user.id
+    // TODO: Add validation to ensure req.body has proper structure
+    db.Collection.update(req.body, { where: { id: req.params.id } }).then(function (dbCollection) {
+      res.json(dbCollection);
+    });
+  });
+
+  app.post('/api/items', auth.isLoggedIn, function (req, res) {
+    // expects an object with properties 'name', 'imageUrl', 'description', 'UserId', 'CollectionId'
+    // we can set 'UserId' with req.user.id
+    // TODO: Add validation to ensure req.body has proper structure
+    db.Item.create(req.body).then(function (dbItem) {
+      res.json(dbItem);
+    });
+  });
+
+  app.delete('/api/items/:id', function (req, res) {
+    db.Item.destroy({ where: { id: req.params.id } }).then(function (dbItem) {
+      res.json(dbItem);
+    });
+  });
+
+  app.put('/api/items/:id', auth.isLoggedIn, function (req, res) {
+    // TODO: Add validation to ensure req.body has proper structure
+    db.Item.update(req.body, { where: { id: req.params.id } }).then(function (dbItem) {
+      res.json(dbItem);
+    });
+  });
 
 
-  // app.delete('/api/collection/:id', function (req, res) {
-  //   db.Collection.destroy({ where: { id: req.params.id } }).then(function (dbCollection) {
-  //     res.json(dbCollection);
-  //   });
-  // });
+  /*********************\
+  |  ADMIN ONLY ROUTES  |
+  \*********************/
 
-  // app.put('/api/collections/:id', function (req, res) {
-  //   // expects an object with properties 'name', 'description', 'UserId'
-  //   db.Collection.update(req.body, { where: { id: req.params.id } }).then(function (dbCollection) {
-  //     res.json(dbCollection);
-  //   });
-  // });
+  // just to check admin stuff.
+  app.get('/admin', auth.isAdmin, function (req, res) {
+    res.send('yes');
+  });
 
-  // // ITEMS API CALLSK
-  // app.get('/api/items', function (req, res) {
-  //   db.Item.findAll({}).then(function (dbItems) {
-  //     res.json(dbItems);
-  //   });
-  // });
+  app.get('/api/users', auth.isAdmin, function (req, res) {
+    db.User.findAll({}).then(function (data) {
+      res.json(data);
+    });
+  });
 
-  // app.get('/api/items/:id', function (req, res) {
-  //   db.Item.findById(req.params.id).then(function (dbItem) {
-  //     res.json(dbItem);
-  //   });
-  // });
 
-  // app.post('/api/items', function (req, res) {
-  //   // expects an object with properties 'name', 'imageUrl', 'description', 'UserId', 'CollectionId'
-  //   db.Item.create(req.body).then(function (dbItem) {
-  //     res.json(dbItem);
-  //   });
-  // });
+  app.post('/api/users', auth.isAdmin, function (req, res) {
+    // expects an object with properties 'name', 'email', 'bio'
+    db.User.create(req.body).then(function (dbUser) {
+      res.json(dbUser);
+    });
+  });
 
-  // app.delete('/api/items/:id', function (req, res) {
-  //   db.Item.destroy({ where: { id: req.params.id } }).then(function (dbItem) {
-  //     res.json(dbItem);
-  //   });
-  // });
+  app.delete('/api/users/:id', auth.isAdmin, function (req, res) {
+    db.User.destroy({ where: { id: req.params.id } }).then(function (dbUser) {
+      res.json(dbUser);
+    });
+  });
 
-  // app.put('/api/items/:id', function (req, res) {
-  //   db.Item.update(req.body, { where: { id: req.params.id } }).then(function (dbItem) {
-  //     res.json(dbItem);
-  //   });
-  // });
+  app.put('/api/users/:id', auth.isAdmin, function (req, res) {
+    db.User.update(req.body, { where: { id: req.params.id } }).then(function (dbUser) {
+      res.json(dbUser);
+    });
+  });
 
-  // // OPPORTUNITIES API CALLS
-  // app.get('/api/opportunities', function (req, res) {
-  //   db.Opportunity.findAll({}).then(function (dbOp) {
-  //     res.json(dbOp);
-  //   });
-  // });
+  app.post('/api/opportunities', auth.isAdmin, function (req, res) {
+    // expects an object with properties 'name', 'description', 'category', 'deadline' (date)
+    // TODO: Add validation to ensure req.body has proper structure
+    db.Opportunity.create(req.body).then(function (dbOp) {
+      res.json(dbOp);
+    });
+  });
 
-  // app.get('/api/opportunities/:id', function (req, res) {
-  //   db.Opportunity.findById(req.params.id).then(function (dbOp) {
-  //     res.json(dbOp);
-  //   });
-  // });
+  app.delete('/api/opportunities/:id', auth.isAdmin, function (req, res) {
+    db.Opportunity.destroy({ where: { id: req.params.id } }).then(function (dbOp) {
+      res.json(dbOp);
+    });
+  });
 
-  // app.post('/api/opportunities', function (req, res) {
-  //   // expects an object with properties 'name', 'description', 'category', 'deadline' (date)
-  //   db.Opportunity.create(req.body).then(function (dbOp) {
-  //     res.json(dbOp);
-  //   });
-  // });
-
-  // app.delete('/api/opportunities/:id', function (req, res) {
-  //   db.Opportunity.destroy({ where: { id: req.params.id } }).then(function (dbOp) {
-  //     res.json(dbOp);
-  //   });
-  // });
-
-  // app.put('/api/opportunities/:id', function (req, res) {
-  //   db.Opportunity.update(req.body, { where: { id: req.params.id } }).then(function (dbOpportunity) {
-  //     res.json(dbOpportunity);
-  //   });
-  // });
+  app.put('/api/opportunities/:id', auth.isAdmin, function (req, res) {
+    // TODO: Add validation to ensure req.body has proper structure
+    db.Opportunity.update(req.body, { where: { id: req.params.id } }).then(function (dbOpportunity) {
+      res.json(dbOpportunity);
+    });
+  });
 
 };

--- a/routes/htmlRoutes.js
+++ b/routes/htmlRoutes.js
@@ -1,4 +1,5 @@
-var db = require('../models');
+const db = require('../models');
+const auth = require('../config/authHelpers');
 
 module.exports = function (app) {
   app.get('/login', function(req, res) {
@@ -26,8 +27,8 @@ module.exports = function (app) {
     });
   });
 
-  // Load example page and pass in an example by id
-  app.get('/opportunities/new', function (req, res) {
+  // Render Form for adding an opportunity.  Require ADMIN permissions
+  app.get('/opportunities/new', auth.isAdmin, function (req, res) {
     res.render('add-opportunity');
   });
 


### PR DESCRIPTION
- Restructure apiRoutes for authentication #38 
- create ./config/authHelpers.js to export `isLoggedIn` and `isAdmin` middleware
- add `TODO` comments to apiRoutes ... there's still a lot of work to do this the Right Way, but that might be beyond the scope here.
- changed an eslint setting because it was annoying and we'll want to be able to comment some things out for testing purposes


